### PR TITLE
Latest js2model changes

### DIFF
--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -75,7 +75,9 @@ class JmgLoader(object):
         self.defaultLoader = jsonref.JsonLoader(store, cache_results)
 
     def __call__(self, uri, **kwargs):
-        json = self.defaultLoader(uri, object_pairs_hook=collections.OrderedDict, **kwargs)
+        json = self.defaultLoader(uri,
+                                  object_pairs_hook=collections.OrderedDict,
+                                  **kwargs)
 
         # keep track of URI that the schema was loaded from
         json['__uri__'] = uri
@@ -590,12 +592,12 @@ class JsonSchema2Model(object):
 
     def get_schema_id(self, schema_object, scope):
 
-        if JsonSchemaKeywords.ID in schema_object:
+        if JsonSchemaKeywords.TYPENAME in schema_object:
+            return schema_object[JsonSchemaKeywords.TYPENAME]
+        elif JsonSchemaKeywords.ID in schema_object:
             return schema_object[JsonSchemaKeywords.ID]
         elif JsonSchema2Model.SCHEMA_URI in schema_object:
             return schema_object[JsonSchema2Model.SCHEMA_URI]
-        elif JsonSchemaKeywords.TYPENAME in schema_object:
-            return schema_object[JsonSchemaKeywords.TYPENAME]
         else:
             assert len(scope)
             return self.mk_class_name(scope[-1])
@@ -950,7 +952,13 @@ class JsonSchema2Model(object):
                 # root_schema = json.load(jsonFile)
                 # base_uri = 'file://' + os.path.split(os.path.realpath(f))[0]
                 base_uri = 'file://' + os.path.realpath(fname)
-                root_schema = jsonref.load(jsonFile, base_uri=base_uri, jsonschema=True, loader=loader, object_pairs_hook=collections.OrderedDict)
+                root_schema = jsonref.load(jsonFile,
+                                           base_uri=base_uri,
+                                           jsonschema=True,
+                                           loader=loader,
+                                           object_pairs_hook=collections.OrderedDict
+                                           )
+
                 # import json
                 # print(json.dumps(root_schema, indent=4, separators=(',', ': ')))
 

--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -126,6 +126,7 @@ class JsonSchemaKeywords(object):
 
     # Extended keywords
     SUPERCLASS = '#superclass'
+    VARIANT_TYPE_ID_PATH = '__typeIdPath'
 
     def __setattr__(self, *_):
         raise ValueError("Trying to change a constant value", self)
@@ -285,6 +286,7 @@ class VariableDef(object):
         self.isArray = False
         self.isVariant = False
         self.variantDefs = []
+        self.variantTypeIdPath = 'type'
 
     def to_dict(self):
         base_dict = {
@@ -312,6 +314,7 @@ class VariableDef(object):
             'isArray': self.isArray,
             'isVariant': self.isVariant,
             'variantDefs': self.variantDefs,
+            'variantTypeIdPath': self.variantTypeIdPath,
         }
         return {k: v for k, v in base_dict.items() if v != None}
 
@@ -871,8 +874,9 @@ class JsonSchema2Model(object):
 
             var_def.isVariant = True
             for variant_type in schema_object[JsonSchemaKeywords.ONE_OF]:
+                var_def.variantTypeIdPath = schema_object.get(JsonSchemaKeywords.VARIANT_TYPE_ID_PATH, 'type')
                 if variant_type.has_key('properties'):
-                    json_type_id = variant_type['properties']['type']['enum'][0]
+                    json_type_id = variant_type['properties'][var_def.variantTypeIdPath]['enum'][0]
                 else:
                     json_type_id = scope[-1]
                 scope.append(json_type_id)

--- a/src/tr/jsonschema/templates_cpp/base.mako
+++ b/src/tr/jsonschema/templates_cpp/base.mako
@@ -71,7 +71,7 @@ def inst_name(value):
 Convert a JSON type to an Objective C type.
 </%doc>\
 <%!
-    def convertType(variableDef):
+    def itemType(variableDef):
 
         if variableDef.isVariant:
             typelist = [convertType(x) for x in variableDef.variantDefs]
@@ -80,15 +80,28 @@ Convert a JSON type to an Objective C type.
             type = variableDef.type
             cppType = type.name if not type.name in typeMap else typeMap[type.name]
 
+        return cppType
+
+    def convertType(variableDef):
+
+        cppType = itemType(variableDef)
+
         if variableDef.isArray:
-             varType = "std::vector<%s>" % cppType
+            varType = "std::vector<%s>" % cppType
         else:
-             varType = cppType
+            varType = cppType
 
         if variableDef.isOptional:
-             varType = "boost::optional<%s>" % varType
+            varType = "boost::optional<%s>" % varType
 
         return varType
+
+    def arrayItemType(variableDef):
+
+        if not variableDef.isArray:
+            raise TypeError("Not an array type " + str(variableDef))
+
+        return itemType(variableDef)
 %>\
 //
 //  ${file_name}

--- a/src/tr/jsonschema/templates_cpp/class.cpp.mako
+++ b/src/tr/jsonschema/templates_cpp/class.cpp.mako
@@ -390,23 +390,20 @@ object["${var_def.json_name}"] = ${inst_name};
 % if v.isVariant:
 <%
 inst_name = base.attr.inst_name(v.name)
-item_name = "item" if v.isArray else inst_name
-accessor = item_name + ".get()" if v.isOptional else item_name
-variant_type_return = "boost::optional<std::string>" if v.isOptional else "std::string"
+inst_name = inst_name + "Value" if v.isArray else inst_name
+accessor = inst_name + ".get()" if v.isOptional and not v.isArray else inst_name
+variant_type_return = "boost::optional<std::string>" if v.isOptional and not v.isArray else "std::string"
 %>\
 % if v.isArray:
-${variant_type_return} ${class_name}::${inst_name}Type(size_t pos) const
+${variant_type_return} ${class_name}::${inst_name}Type(const ${base.attr.arrayItemType(v)}& ${inst_name}) const
 % else:
 ${variant_type_return} ${class_name}::${inst_name}Type() const
 % endif
 {
-% if v.isOptional:
+% if v.isOptional and not v.isArray:
     if (!${inst_name}.is_initialized()) {
         return boost::none;
     }
-% endif
-% if v.isArray:
-    const auto &item = ${inst_name + ".get()" if v.isOptional else inst_name}.at(pos);
 % endif
     class ${inst_name}_get_type : public boost::static_visitor<string>
     {
@@ -423,7 +420,7 @@ ${variant_type_return} ${class_name}::${inst_name}Type() const
         % endif
     % endfor
     };
-    return boost::apply_visitor(${inst_name}_get_type(), ${item_name if not v.isOptional or v.isArray else item_name + ".get()"});
+    return boost::apply_visitor(${inst_name}_get_type(), ${accessor});
 }
 
 % endif

--- a/src/tr/jsonschema/templates_cpp/class.cpp.mako
+++ b/src/tr/jsonschema/templates_cpp/class.cpp.mako
@@ -119,7 +119,7 @@ ${lhs} = ${jsonValueForType(variableDef, rhs)}\
             % for variant in v.variantTypeList():
             ${"if" if loop.first else "else if"} (${valueIsOfJsonInputType(variant["json_schema_type"], "array_item")}\
 % if variant["json_schema_type"] == "object":
- && array_item["type"] == "${variant["json_type_id"]}") {
+ && array_item["${v.variantTypeIdPath}"] == "${variant["json_type_id"]}") {
 % else:
 ) {
 % endif
@@ -148,7 +148,7 @@ ${lhs} = ${jsonValueForType(variableDef, rhs)}\
         % for variant in v.variantTypeList():
         ${"if" if loop.first else "else if"} (${valueIsOfJsonInputType(variant["json_schema_type"], temp_name)}\
 % if variant["json_schema_type"] == "object":
- && ${temp_name}["type"] == "${variant["json_type_id"]}") {
+ && ${temp_name}["${v.variantTypeIdPath}"] == "${variant["json_type_id"]}") {
 % else:
  ) {
 % endif
@@ -414,7 +414,7 @@ ${variant_type_return} ${class_name}::${inst_name}Type() const
     % for variant in v.variantTypeList():
         % if variant["json_schema_type"] == "object":
         string operator()(const ${variant["native_type"]} &value) const {
-            return ${variant["native_type"]}::type_to_string(value.type);
+            return ${variant["native_type"]}::${v.variantTypeIdPath}_to_string(value.${v.variantTypeIdPath});
         }
         % else:
         string operator()(const ${base.attr.typeMap[variant["json_schema_type"]]} &value) const {

--- a/src/tr/jsonschema/templates_cpp/class.h.mako
+++ b/src/tr/jsonschema/templates_cpp/class.h.mako
@@ -87,12 +87,13 @@ ${enumDecl(e)}
 ${propertyDecl(v)}
 % if v.isVariant:
 <%
-variant_type_return = "boost::optional<std::string>" if v.isOptional else "std::string"
+variant_type_return = "boost::optional<std::string>" if v.isOptional and not v.isArray else "std::string"
+inst_name = base.attr.inst_name(v.name)
 %>\
 % if v.isArray:
-    ${variant_type_return} ${base.attr.inst_name(v.name)}Type(size_t pos) const;
+    ${variant_type_return} ${inst_name}ValueType(const ${base.attr.arrayItemType(v)}& ${inst_name}Value) const;
 % else:
-    ${variant_type_return} ${base.attr.inst_name(v.name)}Type() const;
+    ${variant_type_return} ${inst_name}Type() const;
 % endif
 % endif
 % endfor

--- a/test/variant_tests.cpp
+++ b/test/variant_tests.cpp
@@ -58,7 +58,6 @@ TEST_CASE( "Test" ) {
         REQUIRE(obj.optionalLayer == boost::none);
         REQUIRE(obj.optionalLayers == boost::none);
         REQUIRE(obj.optionalLayerType() == boost::none);
-        REQUIRE(obj.optionalLayersType(0) == boost::none);
         REQUIRE(obj.nullablePrimitive == boost::none);
     }
 
@@ -74,7 +73,6 @@ TEST_CASE( "Test" ) {
         REQUIRE(obj.optionalLayer == boost::none);
         REQUIRE(obj.optionalLayers == boost::none);
         REQUIRE(obj.optionalLayerType() == boost::none);
-        REQUIRE(obj.optionalLayersType(0) == boost::none);
         REQUIRE(obj.nullablePrimitive.is_initialized());
         REQUIRE(boost::get<int>(obj.nullablePrimitive.get()) == 1);
     }
@@ -94,15 +92,19 @@ TEST_CASE( "Test" ) {
         REQUIRE(boost::get<FillLayer>(obj.optionalLayer.get()).to_json().dump() == fillLayerData.dump());
 
         REQUIRE(obj.requiredLayers.size() == 2);
-        REQUIRE(obj.requiredLayersType(0) == "photo");
+        REQUIRE(obj.requiredLayersValueType(obj.requiredLayers[0]) == "photo");
         REQUIRE(boost::get<PhotoLayer>(obj.requiredLayers[0]).to_json().dump() == photoLayerData.dump());
-        REQUIRE(obj.requiredLayersType(1) == "fill");
+        REQUIRE(obj.requiredLayersValueType(obj.requiredLayers[1]) == "fill");
         REQUIRE(boost::get<FillLayer>(obj.requiredLayers[1]).to_json().dump() == fillLayerData.dump());
 
-        REQUIRE(obj.optionalLayers.get().size() == 2);
-        REQUIRE(obj.optionalLayersType(0).get() == "fill");
-        REQUIRE(boost::get<FillLayer>(obj.optionalLayers.get()[0]).to_json().dump() == fillLayerData.dump());
-        REQUIRE(obj.optionalLayersType(1).get() == "photo");
-        REQUIRE(boost::get<PhotoLayer>(obj.optionalLayers.get()[1]).to_json().dump() == photoLayerData.dump());
+        {
+            REQUIRE(obj.optionalLayers);
+            auto optionalLayers = obj.optionalLayers.get();
+            REQUIRE(optionalLayers.size() == 2);
+            REQUIRE(obj.optionalLayersValueType(optionalLayers[0]) == "fill");
+            REQUIRE(boost::get<FillLayer>(optionalLayers[0]).to_json().dump() == fillLayerData.dump());
+            REQUIRE(obj.optionalLayersValueType(optionalLayers[1]) == "photo");
+            REQUIRE(boost::get<PhotoLayer>(optionalLayers[1]).to_json().dump() == photoLayerData.dump());
+        }
     }
 }


### PR DESCRIPTION
- Fix validity checks for nested objects
- Support for allowing any field to carry the type of a variant, not just "type". An example of this usage is in the definition of `OperationCommand` and the use of `operationType` [here](https://github.com/FiftyThree/SyncSchema/blob/feature/bridge-schema/Paper/JSONSchema/Bridge/ChannelCommandDetail.schema.json#L14-L32)
- Bug fix around duplicate class definitions

PTAL ... @jasonreisman ? not sure who wants to look at this code :)
