### PR TITLE
Get patternProperties and additionalProperties working

### DIFF
--- a/src/js2model.py
+++ b/src/js2model.py
@@ -39,8 +39,6 @@ def main():
                         help='Class name for root schema object (default: base name of file)')
     # parser.add_argument('-p', '--primitives', action='store_true', default=False,
     # help='Use primitive types in favor of object wrappers')
-    # parser.add_argument('--additional', action='store_true', default=False,
-    #                     help='Include additionalProperties in models')
     parser.add_argument('--novalidate', action='store_true', default=False, help='Skip schema validation')
     parser.add_argument('-o', '--output', default='output', help='Target directory of output files')
     parser.add_argument('--implements', default=None,
@@ -89,7 +87,6 @@ def main():
                                  super_classes=args.super.split(',') if args.super else [],
                                  interfaces=args.implements.split(',') if args.implements else [],
                                  assert_macro = args.assert_macro,
-                                 # include_additional_properties=args.additional,
                                  validate=args.novalidate,
                                  verbose=args.verbose,
                                  skip_deserialization=args.no_deserialize,

--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -335,6 +335,34 @@ class VariableDef(object):
         return {k: v for k, v in base_dict.items() if v != None}
 
     @property
+    def has_array_validation_checks(self):
+        return (self.minItems is not None or
+                self.maxItems is not None)
+
+    @property
+    def has_string_validation_checks(self):
+        return (self.minLength is not None or
+                self.maxLength is not None or
+                self.pattern is not None)
+
+    @property
+    def has_numeric_validation_checks(self):
+        return (self.minimum is not None or
+                self.maximum is not None)
+
+    @property
+    def has_object_validation_checks(self):
+        return self.type.schema_type == "object"
+
+    @property
+    def has_any_validation_checks(self):
+        return (self.has_array_validation_checks or
+                self.has_string_validation_checks or
+                self.has_numeric_validation_checks or
+                self.has_object_validation_checks or
+                self.isVariant)
+
+    @property
     def isOptional(self):
         return self.isNullable or not self.isRequired
 

--- a/src/tr/jsonschema/templates_cpp/class.cpp.mako
+++ b/src/tr/jsonschema/templates_cpp/class.cpp.mako
@@ -366,7 +366,7 @@ pattern, variableDef = classDef.pattern_properties[0]
 % endif
 % endif
 }
-\
+
 <%doc>
 Helper routine for to_json()
 </%doc>\
@@ -541,7 +541,7 @@ ${varType}& ${class_name}::operator[](const std::string &key) {
     return _patternProperties[key];
 }
 
-bool ${class_name}::is_valid_key(const std::string &key) const {
+bool ${class_name}::is_valid_key(const std::string &key) {
     return !is_intrinsic_key(key)\
 % if not acceptsAnyKey:
  && regex_match(key, regex(R"_(${pattern})_", regex_constants::ECMAScript))\
@@ -558,11 +558,11 @@ const ${varType}& ${class_name}::get_property_or(const std::string &key, const $
     return iter != _patternProperties.end() ? iter->second : defaultValue;
 }
 
-bool ${class_name}::is_intrinsic_key(const std::string &key) const {
+bool ${class_name}::is_intrinsic_key(const std::string &key) {
 % if len(classDef.variable_defs):
     static unordered_set<string> intrinsicProperties = {
     % for v in classDef.variable_defs:
-        "${v.name}"
+        "${v.json_name}",
     % endfor
     };
     return intrinsicProperties.find(key) != intrinsicProperties.end();

--- a/src/tr/jsonschema/templates_cpp/class.h.mako
+++ b/src/tr/jsonschema/templates_cpp/class.h.mako
@@ -125,7 +125,7 @@ acceptsAnyKey = (pattern == '.*')
 % else:
 , and must match the pattern "${pattern}".
 % endif
-    bool is_valid_key(const std::string &key) const;
+    static bool is_valid_key(const std::string &key);
 
     // Test to see if the property is set.
     bool has_property(const std::string &key) const;
@@ -138,7 +138,7 @@ acceptsAnyKey = (pattern == '.*')
     const ${varType}& get_property_or(const std::string &key, const ${varType} &defaultValue) const;
 
 private:
-    bool is_intrinsic_key(const std::string &key) const;
+    static bool is_intrinsic_key(const std::string &key);
     std::map<std::string, ${varType}> _patternProperties;
 % endif
 }; // class ${class_name}

--- a/test/Makefile
+++ b/test/Makefile
@@ -6,7 +6,7 @@ include generated_code/generated_srcs.mk
 SOURCES= $(wildcard *.cpp) $(GENERATED_SRCS) third_party/json11/json11.cpp
 OBJDIR := generated_code/obj
 OBJS := $(addprefix $(OBJDIR)/, $(patsubst %.cpp,%.o,$(SOURCES)))
-INPUT_SCHEMAS = jsonSchema/quickstart.schema.json jsonSchema/validation.schema.json jsonSchema/array-test.schema.json jsonSchema/variant.schema.json
+INPUT_SCHEMAS = jsonSchema/quickstart.schema.json jsonSchema/validation.schema.json jsonSchema/array-test.schema.json jsonSchema/variant.schema.json jsonSchema/additional-properties.schema.json jsonSchema/pattern-properties.schema.json
 CC ?= cc
 CXX ?= c++
 LIBCXX ?= c++

--- a/test/additional_properties_tests.cpp
+++ b/test/additional_properties_tests.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <fstream>
+
+#include "catch.hpp"
+#include "optional_io.hpp"
+
+#include "AdditionalPropertiesTest.h"
+
+using namespace boost;
+using namespace json11;
+using namespace std;
+
+using namespace ft::js2model::test;
+
+static Json LoadTestData() {
+    ifstream data("jsonData/additional-properties-test.data.json");
+    stringstream buffer;
+    buffer << data.rdbuf();
+    string error;
+    auto testData = Json::parse(buffer.str(), error);
+    if (!error.empty()) {
+        cerr << "Error loading input data: " << error << endl;
+        exit(-1);
+    }
+    return testData;
+}
+
+TEST_CASE( "Additional properties" ) {
+    auto testData = LoadTestData();
+
+    SECTION( "No additional properties are required" ) {
+        auto obj = AdditionalPropertiesTest(testData[0]);
+        REQUIRE(obj.is_valid());
+        REQUIRE_FALSE(obj.has_property("anotherDescription"));
+        REQUIRE(obj.to_json().dump() == testData[0].dump());
+    }
+
+    SECTION( "Additional properties are accepted" ) {
+        auto obj = AdditionalPropertiesTest(testData[1]);
+        REQUIRE(obj.has_property("anotherDescription"));
+        REQUIRE(obj["anotherDescription"].shortDescription == "another is short");
+        REQUIRE(obj["anotherDescription"].longDescription.get() == "another is long");
+        REQUIRE(obj.is_valid());
+        REQUIRE(obj.to_json().dump() == testData[1].dump());
+    }
+
+    SECTION( "Additional properties are subject to validation" ) {
+        REQUIRE_THROWS_AS(auto obj = AdditionalPropertiesTest(testData[2]), AssertFailedError);
+    }
+
+    SECTION( "Additional properties with crazy keys are accepted" ) {
+        auto obj = AdditionalPropertiesTest(testData[3]);
+        REQUIRE(obj.has_property("*** ??? !!! :)"));
+        REQUIRE(obj["*** ??? !!! :)"].shortDescription == "is short");
+        REQUIRE(obj["*** ??? !!! :)"].longDescription == boost::none);
+        REQUIRE(obj.is_valid());
+        REQUIRE(obj.to_json().dump() == testData[3].dump());
+    }
+
+}

--- a/test/jsonData/additional-properties-test.data.json
+++ b/test/jsonData/additional-properties-test.data.json
@@ -1,0 +1,36 @@
+[
+    {
+        "description": {
+            "short_description": "is short",
+            "long_description": "is long"
+        }
+    },
+    {
+        "description": {
+            "short_description": "is short",
+            "long_description": "is long"
+        },
+        "anotherDescription": {
+            "short_description": "another is short",
+            "long_description": "another is long"
+        }
+    },
+    {
+        "description": {
+            "short_description": "is short",
+            "long_description": "is long"
+        },
+        "anotherDescription": {
+            "long_description": "another is long"
+        }
+    },
+    {
+        "description": {
+            "short_description": "is short",
+            "long_description": "is long"
+        },
+        "*** ??? !!! :)": {
+            "short_description": "is short"
+        }
+    }
+]

--- a/test/jsonData/pattern-properties-test.data.json
+++ b/test/jsonData/pattern-properties-test.data.json
@@ -1,0 +1,52 @@
+[
+    {
+        "prop_builtinProperty": "hello",
+        "location": {
+        },
+        "phoneNumbers": {
+        }
+    },
+    {
+        "prop_builtinProperty": "hello",
+        "location": {
+            "loc_home": "not a real location"
+        },
+        "phoneNumbers": {
+        }
+    },
+    {
+        "prop_builtinProperty": "hello",
+        "location": {
+        },
+        "phoneNumbers": {
+            "number_x": []
+        }
+    },
+    {
+        "prop_builtinProperty": "hello",
+        "location": {
+            "locWork": "work"
+        },
+        "phoneNumbers": {
+        }
+    },
+    {
+        "prop_builtinProperty": "hello",
+        "location": {
+            "loc_one": "work",
+            "loc_2": "home",
+            "loc_   ???***": "home"
+        },
+        "phoneNumbers": {
+            "number_1": [{
+                "number": "(206)555-1212"
+            }],
+            "number_ more numbers": [{
+                "number": "(206)555-1213"
+            },{
+                "number": "(206)555-1214"
+            }
+            ]
+        }
+    }
+]

--- a/test/jsonSchema/additional-properties.schema.json
+++ b/test/jsonSchema/additional-properties.schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "typeName": "AdditionalPropertiesTest",
+    "required": [
+        "description"
+    ],
+    "properties": {
+        "description": {
+            "type": "object",
+            "typeName": "Description",
+            "required": [
+                "short_description"
+            ],
+            "properties": {
+                "short_description": {
+                    "type": "string"
+                },
+                "long_description": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "patternProperties": {
+        "^S_": { "type": "string" },
+        "^I_": { "type": "integer" }
+    },
+    "additionalProperties": { "$ref" : "#/properties/description" }
+}
+

--- a/test/jsonSchema/additional-properties.schema.json
+++ b/test/jsonSchema/additional-properties.schema.json
@@ -22,10 +22,6 @@
             }
         }
     },
-    "patternProperties": {
-        "^S_": { "type": "string" },
-        "^I_": { "type": "integer" }
-    },
     "additionalProperties": { "$ref" : "#/properties/description" }
 }
 

--- a/test/jsonSchema/pattern-properties.schema.json
+++ b/test/jsonSchema/pattern-properties.schema.json
@@ -3,24 +3,24 @@
     "type": "object",
     "typeName": "PatternPropertiesTest",
     "required": [
-        "description"
+        "prop_builtinProperty", "location", "phoneNumbers"
     ],
     "properties": {
-        "int_builtinProperty": { "type": "string" },
+        "prop_builtinProperty": { "type": "string" },
         "location": {
             "type": "object",
             "typeName": "PatternLocation",
             "patternProperties": {
-                "^loc_": {
+                "^loc_.*": {
                     "enum": ["home", "work"]
                 }
             }
         },
-        "numbers": {
+        "phoneNumbers": {
             "type": "object",
             "typeName": "PatternPhoneNumbers",
             "patternProperties": {
-                "^number_": {
+                "^number_.*": {
                     "type": "array",
                     "items": {
                         "type": "object",
@@ -39,7 +39,10 @@
         }
     },
     "patternProperties": {
-        "^int_": { "type": "integer" }
+        "^prop_.*": {
+            "type": "integer",
+            "minimum": 0
+        }
     }
 }
 

--- a/test/jsonSchema/pattern-properties.schema.json
+++ b/test/jsonSchema/pattern-properties.schema.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "typeName": "PatternPropertiesTest",
+    "required": [
+        "description"
+    ],
+    "properties": {
+        "int_builtinProperty": { "type": "string" },
+        "location": {
+            "type": "object",
+            "typeName": "PatternLocation",
+            "patternProperties": {
+                "^loc_": {
+                    "enum": ["home", "work"]
+                }
+            }
+        },
+        "numbers": {
+            "type": "object",
+            "typeName": "PatternPhoneNumbers",
+            "patternProperties": {
+                "^number_": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "typeName": "PatternPhoneNumber",
+                        "required": ["number"],
+                        "minItems": 1,
+                        "properties": {
+                            "number": {
+                                "type": "string",
+                                "pattern": "^(\\([0-9]{3}\\))?[0-9]{3}-[0-9]{4}$"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "patternProperties": {
+        "^int_": { "type": "integer" }
+    }
+}
+

--- a/test/optional_io.hpp
+++ b/test/optional_io.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <boost/optional.hpp>
+
+namespace boost
+{
+inline std::ostream& operator << ( std::ostream& os, none_t const& value ) {
+    os << "boost::none";
+    return os;
+}
+
+template<typename T>
+std::ostream& operator << ( std::ostream& os, optional<T> const& value ) {
+    if (value.is_initialized())
+        os << "initialized";
+    else
+        os << none;
+    return os;
+}
+}
+

--- a/test/pattern_properties_tests.cpp
+++ b/test/pattern_properties_tests.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+#include <fstream>
+
+#include "catch.hpp"
+#include "optional_io.hpp"
+
+#include "AdditionalPropertiesTest.h"
+
+using namespace boost;
+using namespace json11;
+using namespace std;
+
+using namespace ft::js2model::test;
+
+static Json LoadTestData() {
+    ifstream data("jsonData/additional-properties-test.data.json");
+    stringstream buffer;
+    buffer << data.rdbuf();
+    string error;
+    auto testData = Json::parse(buffer.str(), error);
+    if (!error.empty()) {
+        cerr << "Error loading input data: " << error << endl;
+        exit(-1);
+    }
+    return testData;
+}
+
+// TEST_CASE( "xxx Additional properties" ) {
+//     auto testData = LoadTestData();
+
+//     SECTION( "No additional properties are required" ) {
+//         auto obj = AdditionalPropertiesTest(testData[0]);
+//         REQUIRE(obj.is_valid());
+//         REQUIRE_FALSE(obj.has_property("anotherDescription"));
+//         REQUIRE(obj.to_json().dump() == testData[0].dump());
+//     }
+
+//     SECTION( "Additional properties are accepted" ) {
+//         auto obj = AdditionalPropertiesTest(testData[1]);
+//         REQUIRE(obj.has_property("anotherDescription"));
+//         REQUIRE(obj["anotherDescription"].shortDescription == "another is short");
+//         REQUIRE(obj["anotherDescription"].longDescription.get() == "another is long");
+//         REQUIRE(obj.is_valid());
+//         REQUIRE(obj.to_json().dump() == testData[0].dump());
+//     }
+
+//     SECTION( "Additional properties are subject to validation" ) {
+//         REQUIRE_THROWS_AS(auto obj = AdditionalPropertiesTest(testData[2]), AssertFailedError);
+//     }
+
+//     SECTION( "Additional properties with crazy keys are accepted" ) {
+//         auto obj = AdditionalPropertiesTest(testData[3]);
+//         REQUIRE(obj.has_property("*** ??? !!! :)"));
+//         REQUIRE(obj["*** ??? !!! :)"].shortDescription == "is short");
+//         REQUIRE(obj["*** ??? !!! :)"].longDescription == boost::none);
+//         REQUIRE(obj.is_valid());
+//         REQUIRE(obj.to_json().dump() == testData[0].dump());
+//     }
+
+// }

--- a/test/pattern_properties_tests.cpp
+++ b/test/pattern_properties_tests.cpp
@@ -62,5 +62,31 @@ TEST_CASE( "Pattern properties" ) {
         auto obj = PatternPropertiesTest(testData[4]);
         REQUIRE(obj.is_valid());
         REQUIRE(obj.to_json().dump() == testData[4].dump());
+
+        REQUIRE(obj.location.has_property("loc_one"));
+        REQUIRE(obj.location.has_property("loc_2"));
+        REQUIRE(obj.location.has_property("loc_   ???***"));
+
+        REQUIRE(obj.location["loc_one"] == PatternLocation::Location::Work);
+        REQUIRE(obj.location["loc_2"] == PatternLocation::Location::Home);
+        REQUIRE(obj.location["loc_   ???***"] == PatternLocation::Location::Home);
+    }
+
+    SECTION( "get_property_or works correctly" ) {
+        auto obj = PatternLocation();
+        auto key = "loc_number_one";
+
+        // No keys should be set
+        REQUIRE_FALSE(obj.has_property(key));
+
+        // get_property_or should return the default value,
+        // and not modify the object
+        REQUIRE(obj.get_property_or(key, PatternLocation::Location::Home) == PatternLocation::Location::Home);
+        REQUIRE_FALSE(obj.has_property(key));
+
+        // Set the value. get_property_or should now return it
+        obj[key] = PatternLocation::Location::Work;
+        REQUIRE(obj.has_property(key));
+        REQUIRE(obj.get_property_or(key, PatternLocation::Location::Home) == PatternLocation::Location::Work);
     }
 }

--- a/test/variant_tests.cpp
+++ b/test/variant_tests.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 
 #include "catch.hpp"
+#include "optional_io.hpp"
 
 #include "Variant.h"
 
@@ -22,23 +23,6 @@ static Json LoadTestData(const string &jsonFile) {
         exit(-1);
     }
     return testData;
-}
-
-namespace boost
-{
-std::ostream& operator << ( std::ostream& os, none_t const& value ) {
-    os << "boost::none";
-    return os;
-}
-
-template<typename T>
-std::ostream& operator << ( std::ostream& os, optional<T> const& value ) {
-    if (value.is_initialized())
-        os << "initialized";
-    else
-        os << none;
-    return os;
-}
 }
 
 TEST_CASE( "Test" ) {


### PR DESCRIPTION
Add support for [patternProperties](http://spacetelescope.github.io/understanding-json-schema/reference/object.html#pattern-properties) and [additionalProperties](http://spacetelescope.github.io/understanding-json-schema/reference/object.html#properties) to js2model. We're going to need this if we're going to support unpacking metadata from the service without turning objects into arrays, as seen here: https://github.com/FiftyThree/Studio/blob/master/paperjs/src/PaperClient.js#L187-L199.

PTAL @thomasmarsh or @jasonreisman 