### PR TITLE
Restore code that prefixed member access with `this->`

### DIFF
--- a/src/tr/jsonschema/templates_cpp/class.cpp.mako
+++ b/src/tr/jsonschema/templates_cpp/class.cpp.mako
@@ -343,13 +343,14 @@ check_valid()
 </%doc>\
 void ${class_name}::check_valid() const {
 % for v in classDef.variable_defs:
+<% member_variable = "this->" + v.name %>\
 % if v.has_any_validation_checks:
 % if v.isOptional:
-    if (${v.name}.is_initialized()) {
-        ${capture(emit_validation_checks, v.name + ".get()", v) | indent8}
+    if (${member_variable}.is_initialized()) {
+        ${capture(emit_validation_checks, member_variable + ".get()", v) | indent8}
     }
 % else:
-    ${capture(emit_validation_checks, v.name, v) | indent4}
+    ${capture(emit_validation_checks, member_variable, v) | indent4}
 % endif
 % endif
 % endfor
@@ -359,7 +360,7 @@ assert(len(classDef.pattern_properties) == 1)
 pattern, variableDef = classDef.pattern_properties[0]
 %>\
 % if variableDef.has_any_validation_checks:
-    for (const auto kv : _patternProperties) {
+    for (const auto kv : this->_patternProperties) {
         // TODO: should embed the actual key value here
         ${capture(emit_validation_checks, "kv.second", variableDef) | indent8}
     }
@@ -430,16 +431,17 @@ Json ${class_name}::to_json() const {
     ${assert_macro}(is_valid());
     auto object = Json::object();
 % for v in classDef.variable_defs:
+<% member_variable = "this->" + v.name %>\
 % if v.isOptional:
-    if (${v.name}.is_initialized()) {
-        ${capture(emit_assignment, v.name + ".get()", quote(v.json_name), v) | indent8}
+    if (${member_variable}.is_initialized()) {
+        ${capture(emit_assignment, member_variable + ".get()", quote(v.json_name), v) | indent8}
 % if v.isNullable:
     } else {
         object["${v.json_name}"] = Json(nullptr);
 % endif
     }
 % else:
-    ${capture(emit_assignment, v.name, quote(v.json_name), v) | indent4}
+    ${capture(emit_assignment, member_variable, quote(v.json_name), v) | indent4}
 % endif
 % endfor
 % if classDef.has_pattern_properties:

--- a/src/tr/jsonschema/templates_cpp/class.h.mako
+++ b/src/tr/jsonschema/templates_cpp/class.h.mako
@@ -137,6 +137,12 @@ acceptsAnyKey = (pattern == '.*')
 % endif
     const ${varType}& get_property_or(const std::string &key, const ${varType} &defaultValue) const;
 
+    // Get a const ref to the dynamic property map, for iteration.
+    // Writes still must go through operator[], so that property patterns can be validated.
+    const std::map<std::string, ${varType}>& dynamic_properties() const {
+        return _patternProperties;
+    }
+
 private:
     static bool is_intrinsic_key(const std::string &key);
     std::map<std::string, ${varType}> _patternProperties;

--- a/test/pattern_properties_tests.cpp
+++ b/test/pattern_properties_tests.cpp
@@ -56,6 +56,7 @@ TEST_CASE( "Pattern properties" ) {
         auto obj = PatternPropertiesTest(testData[3]);
         REQUIRE(obj.is_valid());
         REQUIRE(obj.location.to_json().dump() == "{}");
+        REQUIRE(obj.location.dynamic_properties().empty());
     }
 
     SECTION( "Pattern properties are accepted" ) {
@@ -70,6 +71,8 @@ TEST_CASE( "Pattern properties" ) {
         REQUIRE(obj.location["loc_one"] == PatternLocation::Location::Work);
         REQUIRE(obj.location["loc_2"] == PatternLocation::Location::Home);
         REQUIRE(obj.location["loc_   ???***"] == PatternLocation::Location::Home);
+
+        REQUIRE(obj.location.dynamic_properties().size() == 3);
     }
 
     SECTION( "get_property_or works correctly" ) {


### PR DESCRIPTION
I removed some of these in #8 but decided I felt better if they were still there. Will prevent future name collisions if someone adds a property named `object` to a schema 😄 

Before:
```c++
Json Channel::to_json() const {
    DebugAssert(is_valid());
    auto object = Json::object();
    object["uuid"] = uuid;
    object["type"] = type_to_string(type);
    return Json(object);
}
```

After:
```c++
Json Channel::to_json() const {
    DebugAssert(is_valid());
    auto object = Json::object();
    object["uuid"] = this->uuid;
    object["type"] = type_to_string(this->type);
    return Json(object);
}
```

PTAL @petersibley 