### PR TITLE
Small js2model fixes

### DIFF
--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -1005,7 +1005,7 @@ class JsonSchema2Model(object):
                 base_uri = 'file://' + os.path.realpath(fname)
                 root_schema = jsonref.load(jsonFile,
                                            base_uri=base_uri,
-                                           jsonschema=True,
+                                           jsonschema=False, # resolve references relative to local tree, not against "id" URIs
                                            loader=loader,
                                            object_pairs_hook=collections.OrderedDict
                                            )

--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -215,6 +215,12 @@ class ClassDef(object):
     def has_var_patterns(self):
         return True if len([d for d in self.variable_defs if d.pattern is not None]) else False
 
+    @property
+    def has_string_length_checks(self):
+        for v in self.variable_defs:
+            if v.minLength is not None or v.maxLength is not None:
+                return True
+        return False
 
 class EnumDef(object):
     def __init__(self):

--- a/src/tr/jsonschema/templates_cpp/class.cpp.mako
+++ b/src/tr/jsonschema/templates_cpp/class.cpp.mako
@@ -121,22 +121,22 @@ ${generateBasicAssignmentFromJson(variableDef, lhs, rhs, lhsIsArray)}
 String validation
 </%doc>
 <%def name='emit_string_validation_checks(inst_name, var_def)'>\
-{
-    auto codepoint_count = ::js2model::utf8_codepoint_count(${inst_name});
+% if var_def.minLength is not None or var_def.maxLength is not None:
+auto ${var_def.name}_codepoint_count = ::js2model::utf8_codepoint_count(${inst_name});
+% endif
 % if var_def.minLength is not None:
-    if (codepoint_count < ${var_def.minLength})
-        throw out_of_range("${var_def.name} too short");
+if (${var_def.name}_codepoint_count < ${var_def.minLength})
+    throw out_of_range("${var_def.name} too short");
 % endif
 % if var_def.maxLength is not None:
-    if (codepoint_count > ${var_def.maxLength})
-        throw out_of_range("${var_def.name} too long");
+if (${var_def.name}_codepoint_count > ${var_def.maxLength})
+    throw out_of_range("${var_def.name} too long");
 % endif
 % if var_def.pattern:
-    auto ${var_def.name}_regex = regex(R"_(${var_def.pattern})_", regex_constants::ECMAScript);
-    if (!regex_match(${inst_name}, ${var_def.name}_regex))
-        throw invalid_argument("${var_def.name} doesn't match regex pattern");
+auto ${var_def.name}_regex = regex(R"_(${var_def.pattern})_", regex_constants::ECMAScript);
+if (!regex_match(${inst_name}, ${var_def.name}_regex))
+    throw invalid_argument("${var_def.name} doesn't match regex pattern");
 % endif
-}
 </%def>\
 
 <%doc>
@@ -248,8 +248,10 @@ This block contains the generated code
 #include <unordered_set>
 % endif
 #include <vector>
+% if classDef.has_string_length_checks:
 
 #include "UTF8Utils.h"
+% endif
 
 using namespace std;
 using namespace json11;


### PR DESCRIPTION
- Tweak the code generation for string validation checks, so that we can minimize differences in existing generated code
- Change how we parse JSON References - explicitly ignore "id" URIs in schemas and resolve all relative references against the file system

PTAL @petersibley 