### PR TITLE
Feature/all of

### DIFF
--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -724,13 +724,11 @@ class JsonSchema2Model(object):
             # in the "allOf".
             if JsonSchemaKeywords.ALL_OF in schema_object:
 
-                allOfs = schema_object[JsonSchemaKeywords.ALL_OF]
-                for allOf in allOfs:
-	                
-	                if JsonSchemaKeywords.PROPERTIES in allOf:
-
-	                    properties = allOf[JsonSchemaKeywords.PROPERTIES]
-	                    required_properties = allOf.get(JsonSchemaKeywords.REQUIRED, {})
+                sub_schemas = schema_object[JsonSchemaKeywords.ALL_OF]
+                for sub_schema in sub_schemas:	                
+	                if JsonSchemaKeywords.PROPERTIES in sub_schema:
+	                    properties = sub_schema[JsonSchemaKeywords.PROPERTIES]
+	                    required_properties = sub_schema.get(JsonSchemaKeywords.REQUIRED, {})
 
 	                    for prop in properties.keys():
 	                        scope.append(prop)

--- a/src/tr/jsonschema/templates_cpp/class.h.mako
+++ b/src/tr/jsonschema/templates_cpp/class.h.mako
@@ -72,9 +72,15 @@ namespace ${ns} {
 class_name = classDef.name
 superClass = classDef.superClasses[0] if len(classDef.superClasses) else None
 %>
-class ${class_name + ((': protected ' + superClass) if superClass else '')}
+class ${class_name + ((' : public ' + superClass) if superClass else '')}
 {
 public:
+    ALIAS_PTR_TYPES(${class_name});
+
+    // TODO: We should eventually make the destructor private to ensure we
+    //       only allocate instances of this class using std::make_shared().
+    ~${class_name}() {}
+
 % for e in classDef.enum_defs:
 ${enumDecl(e)}
 % endfor


### PR DESCRIPTION
* Add `Ptr` to native classes.
   * Now that we're doing away with the wrappers (ie. SyncEngineMessage and SyncAction), we're going to be passing around the native classes much more often and will want shared_ptrs to them.
* Make inheritance of native classes public.
  * Again, the native classes will need common base class(es).  
  * We're going to be doing type-based dispatch and will sometimes use base classes to do so.
* Honor `allOf` keyword in JSON Schemas.
  * Our new schemas use `allOf` to inherit properties from other schemas.  js2model doesn't seem (AFAIK) to support `allOf`.  I've added in a minimum set of support.
  * See: https://github.com/FiftyThree/SyncSchema/pull/57
  * See: https://spacetelescope.github.io/understanding-json-schema/reference/combining.html#allof

PTAL @thomasmarsh @ryanwe 
CC @jasonreisman 