### PR TITLE
Feature/js2model error logging (PPR-7751)

### DIFF
--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -521,6 +521,12 @@ class JsonSchema2Model(object):
             # from pprint import pprint
             # pprint(classDef)
             # import pdb; pdb.set_trace()
+            
+            if template_files.header_template:
+				print('render_model_to_file', classDef.header_file, template_files.header_template)
+				print('\t classDef.superClasses', classDef.superClasses)
+# 				sys.exit(0)
+            	
             if template_files.header_template:
                 self.render_model_to_file(classDef, classDef.header_file, template_files.header_template)
 
@@ -686,6 +692,13 @@ class JsonSchema2Model(object):
 
             # set super class, in increasing precendence
             extended = False
+            if 'superclass' in schema_object:
+            	superclass_name = schema_object['superclass']
+            	print('superclass_name', superclass_name)
+            	print('superclass_name', type(superclass_name))
+            	assert (isinstance(superclass_name, str) or isinstance(superclass_name, unicode))
+            	class_def.superClasses = [superclass_name]
+            	pass
             if JsonSchemaKeywords.EXTENDS in schema_object:
                 prop_var_def = self.create_model(schema_object[JsonSchemaKeywords.EXTENDS], scope)
                 class_def.superClasses = [prop_var_def.type.name]

--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -722,7 +722,7 @@ class JsonSchema2Model(object):
             	superclass_name = schema_object['superclass']
             	assert (isinstance(superclass_name, str) or isinstance(superclass_name, unicode))
             	class_def.superClasses = [superclass_name]
-            	pass
+
             if JsonSchemaKeywords.EXTENDS in schema_object:
                 prop_var_def = self.create_model(schema_object[JsonSchemaKeywords.EXTENDS], scope)
                 class_def.superClasses = [prop_var_def.type.name]

--- a/src/tr/jsonschema/jsonschema2model.py
+++ b/src/tr/jsonschema/jsonschema2model.py
@@ -513,7 +513,8 @@ class JsonSchema2Model(object):
 
         template_files = self.template_manager.get_template_files(self.lang)
         conventions = self.template_manager.get_conventions(self.lang)
-
+		
+        translator_class_names = []
         for classDef in self.models.values():
             if len(classDef.variable_defs) == 0 and len(classDef.pattern_properties) == 0:
                 print("Not emitting empty class %s" % classDef.name)
@@ -522,10 +523,9 @@ class JsonSchema2Model(object):
             # pprint(classDef)
             # import pdb; pdb.set_trace()
             
-            if template_files.header_template:
-				print('render_model_to_file', classDef.header_file, template_files.header_template)
-				print('\t classDef.superClasses', classDef.superClasses)
-# 				sys.exit(0)
+            isMessageType = classDef.superClasses
+            if isMessageType:
+                translator_class_names.append(classDef.name)
             	
             if template_files.header_template:
                 self.render_model_to_file(classDef, classDef.header_file, template_files.header_template)
@@ -541,6 +541,32 @@ class JsonSchema2Model(object):
         # The `models.h` file is just noise
         # for global_template in template_files.global_templates:
         #     self.render_global_template(self.models.values(), global_template)
+        
+        translator_file_name = 'GenericMessageTranslator.h'
+        translator_template = 'translator.h.mako'
+        self.render_translation_to_file(translator_class_names, translator_file_name, translator_template)
+		
+    def render_translation_to_file(self, class_names, src_file_name, templ_name):
+ 
+        outfile_name = os.path.join(self.outdir, src_file_name)
+
+        template = self.makolookup.get_template(templ_name)
+
+        with open(outfile_name, 'w') as f:
+
+            try:
+                self.verbose_output("Writing %s" % outfile_name)
+                f.write(template.render(class_names=class_names,
+                                        include_files=self.include_files,
+                                        assert_macro=self.assert_macro,
+                                        namespace=self.namespace,
+                                        timestamp=str(datetime.date.today()),
+                                        year=int(datetime.date.today().year),
+                                        file_name=src_file_name,
+                                        skip_deserialization=self.skip_deserialization))
+            except:
+                print(exceptions.text_error_template().render())
+                sys.exit(-1)
 
     def render_model_to_file(self, class_def, src_file_name, templ_name):
 
@@ -694,8 +720,6 @@ class JsonSchema2Model(object):
             extended = False
             if 'superclass' in schema_object:
             	superclass_name = schema_object['superclass']
-            	print('superclass_name', superclass_name)
-            	print('superclass_name', type(superclass_name))
             	assert (isinstance(superclass_name, str) or isinstance(superclass_name, unicode))
             	class_def.superClasses = [superclass_name]
             	pass

--- a/src/tr/jsonschema/templates_cpp/class.cpp.mako
+++ b/src/tr/jsonschema/templates_cpp/class.cpp.mako
@@ -346,6 +346,18 @@ bool ${class_name}::is_valid() const {
 }
 
 <%doc>
+is_valid()
+</%doc>\
+std::string ${class_name}::get_validity_error() const {
+    try {
+        check_valid();
+    } catch (const exception &e) {
+        return e.what();
+    }
+    return "";
+}
+
+<%doc>
 check_valid()
 </%doc>\
 void ${class_name}::check_valid() const {

--- a/src/tr/jsonschema/templates_cpp/class.h.mako
+++ b/src/tr/jsonschema/templates_cpp/class.h.mako
@@ -101,6 +101,8 @@ public:
 
     /// Returns true if the contents of this object match the schema
     bool is_valid() const;
+    /// Returns a non-empty string if the contents of this object do not match the schema
+    std::string get_validity_error() const;
     /// Throws if the contents of this object do not match the schema
     void check_valid() const;
 

--- a/src/tr/jsonschema/templates_cpp/class.h.mako
+++ b/src/tr/jsonschema/templates_cpp/class.h.mako
@@ -80,7 +80,7 @@ superClass = classDef.superClasses[0] if len(classDef.superClasses) else None
 class ${class_name + ((' : public ' + superClass) if superClass else '')}
 {
 public:
-    ALIAS_PTR_TYPES(${class_name});
+    using Ptr = std::shared_ptr<${class_name}>;
 
 % for e in classDef.enum_defs:
 ${enumDecl(e)}

--- a/src/tr/jsonschema/templates_cpp/class.h.mako
+++ b/src/tr/jsonschema/templates_cpp/class.h.mako
@@ -64,6 +64,11 @@ has_variants = any([v.isVariant for v in classDef.variable_defs])
 #include "${include_file}"
 % endfor
 % endif
+% if classDef.superClasses:
+% for superClass in classDef.superClasses:
+#include "SyncClient/${superClass}.h"
+% endfor
+% endif
 
 % for ns in namespace.split('::'):
 namespace ${ns} {

--- a/src/tr/jsonschema/templates_cpp/translator.h.mako
+++ b/src/tr/jsonschema/templates_cpp/translator.h.mako
@@ -39,7 +39,7 @@ public:
 
 // This class is intended to eventually supercede SyncEngineMessageTranslator.
 //
-// Its contents will eventually be code-generated from the JSON schemas.
+// Its contents are code-generated from the JSON schemas.
 class GenericMessageTranslator
 {
 private:

--- a/src/tr/jsonschema/templates_cpp/translator.h.mako
+++ b/src/tr/jsonschema/templates_cpp/translator.h.mako
@@ -1,0 +1,87 @@
+<%doc>
+Copyright (c) 2016 FiftyThree, Inc.
+</%doc>
+<%inherit file="base.mako" />
+<%namespace name="base" file="base.mako" />
+<%block name="code">
+#pragma once
+
+#include <json11/json11.hpp>
+
+#include "Core/Memory.h"
+#include "SyncClient/NativeAction.h"
+#include "SyncClient/Schema/ModelAction.h"
+% if class_names:
+% for class_name in class_names:
+#include "SyncClient/Schema/${class_name}.h"
+% endfor
+% endif
+
+BEGIN_SYNC_NAMESPACE
+
+class GenericMessageTranslatorDelegate
+{
+public:
+    ALIAS_PTR_TYPES(GenericMessageTranslatorDelegate);
+
+protected:
+    ~GenericMessageTranslatorDelegate() {}
+
+public:
+    virtual void DispatchRemoteAction(const schema::ClientPresenceUpdateAction::Ptr &action) = 0;
+
+    virtual void DispatchRemoteAction(const schema::TeamPresenceSnapshotAction::Ptr &action) = 0;
+
+    virtual void DispatchRemoteAction(const schema::ModelAction::Ptr &action) = 0;
+};
+
+#pragma mark -
+
+// This class is intended to eventually supercede SyncEngineMessageTranslator.
+//
+// Its contents will eventually be code-generated from the JSON schemas.
+class GenericMessageTranslator
+{
+private:
+    GenericMessageTranslator() {}
+
+public:
+    // Until GenericMessageTranslator completely supercedes SyncEngineMessageTranslator,
+    // this method returns true IFF it was able to translate and dispatch the message.
+    static bool TranslateAndDispatchJSONMessage(const json11::Json &json,
+                                                const GenericMessageTranslatorDelegate::Ptr &delegate)
+    {
+        DebugAssert(delegate);
+
+        // We code generate this file so that the contents of this cascading if-else statement
+        // can be derived from the JSON schemas.
+        if (!json["type"].is_string()) {
+            PROD_MLOG_DEBUG(FTLogSyncClient, "Message missing type: %s", json.dump().c_str());
+% if class_names:
+% for class_name in class_names:
+        } else if (json["type"] == "${class_name}") {
+            const auto message = std::make_shared<schema::${class_name}>(json);
+            if (message->is_valid()) {
+                delegate->DispatchRemoteAction(message);
+
+                return true;
+            } else {
+                FTFail("Invalid ${class_name} message: %s", message->get_validity_error().c_str());
+            }
+% endfor
+% endif
+        } else {
+            // TODO: Once GenericMessageTranslator replaces SyncEngineMessageTranslator,
+            // this block should assert, since an unexpected message was received.
+            // FTFail("Un-implemented action");
+
+            PROD_MLOG_DEBUG(FTLogSyncClient, "Message has unknown type: %s", json.dump().c_str());
+        }
+
+        return false;
+    }
+};
+
+END_SYNC_NAMESPACE
+
+</%block>


### PR DESCRIPTION
* Add get_validity_error() method to native classes so that we can log validation errors.
* Rework how superclasses are specified in js2model.
  * https://github.com/FiftyThree/SyncSchema/pull/61
* Code generate GenericMessageTranslator.

PTAL @petersibley 